### PR TITLE
[openshift/template.yaml] set resources->requests->memory

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -71,6 +71,8 @@ objects:
             periodSeconds: 60
             timeoutSeconds: 30
           resources:
+            requests:
+              memory: "128Mi"
             limits:
               memory: "512Mi"
         restartPolicy: Always


### PR DESCRIPTION
If the `requests:` is not set, it's set to match the `limit:`. [[1]](https://kubernetes.io/docs/tasks/administer-cluster/memory-default-namespace/#what-if-you-specify-a-containers-limit-but-not-its-request)
Amount estimated by checking running containers on staging & prod.